### PR TITLE
Fix malformed HTML and broken paths in index.html

### DIFF
--- a/DayZen/index.html
+++ b/DayZen/index.html
@@ -555,7 +555,7 @@
 
       <!-- Logo -->
       <a class="navbar-brand d-flex align-items-center" href="#">
-        <img src="../assets/images/logos/logoWhite.png" alt="DayZen Logo" width="32" style="filter: invert(1);">
+        <img src="assets/images/logos/logoWhite.png" alt="DayZen Logo" width="32" style="filter: invert(1);">
         <h1 class="ms-3 mb-0">DayZen</h1>
       </a>
 
@@ -570,38 +570,34 @@
 
           <li class="nav-item">
             <a class="nav-link" href="#">
-              <img src="../assets/images/illustrations/home.png" class="nav-img" /> Home
+              <img src="assets/images/illustrations/home.png" class="nav-img" /> Home
             </a>
           </li>
 
           <li class="nav-item">
-            <a class="nav-link" href="about.html">
-              <img src="../assets/images/Illustrations/about_us.png" class="nav-img" />
             <a class="nav-link" href="pages/about.html">
-              <img src="../assets/images/illustrations/about_us.png" class="nav-img" />
+              <img src="assets/images/illustrations/about_us.png" class="nav-img" />
               About Us
             </a>
           </li>
 
           <li class="nav-item">
-            <a class="nav-link" href="blog.html">
-              <img src="../assets/images/Illustrations/blog.png" class="nav-img" />
-            <a class="nav-link" href="#">
-              <img src="../assets/images/illustrations/blog.png" class="nav-img" />
+            <a class="nav-link" href="pages/blog.html">
+              <img src="assets/images/illustrations/blog.png" class="nav-img" />
               Blog
             </a>
           </li>
 
           <li class="nav-item">
             <a class="nav-link" href="#contact">
-              <img src="../assets/images/illustrations/communication.png" class="nav-img" />
+              <img src="assets/images/illustrations/communication.png" class="nav-img" />
               Contact
             </a>
           </li>
 
           <li class="nav-item">
-            <a class="nav-link" href="register.html">
-              <img src="../assets/images/icons/userColor.png" class="nav-img" />
+            <a class="nav-link" href="pages/register.html">
+              <img src="assets/images/icons/userColor.png" class="nav-img" />
               Login
             </a>
           </li>
@@ -615,7 +611,7 @@
 
       <!-- Theme Icon -->
       <div class="ms-4 d-none d-lg-block">
-        <img src="../assets/images/icons/sun.png" alt="Theme" width="20" style="cursor: pointer; opacity: 0.5;">
+        <img src="assets/images/icons/sun.png" alt="Theme" width="20" style="cursor: pointer; opacity: 0.5;">
       </div>
 
     </div>
@@ -629,7 +625,7 @@
     <p>
       Easily plan, track and manage your daily routines with DayZen. Designed for peace and clarity.
     </p>
-    <a href="../pages/register.html" class="btn btn-primary">
+    <a href="pages/register.html" class="btn btn-primary">
       Start Now
     </a>
   </div>
@@ -646,10 +642,8 @@
 
       <div class="col-md-4">
         <div class="feature-card">
-          <div class="mb-4 d-flex align-items-center justify-content-center" style="height: 60px;">
-            <img src="../assets/images/illustrations/productivity.png" alt="">
           <div class="icon-wrap">
-            <img src="../assets/images/Illustrations/productivity.png" alt="">
+            <img src="assets/images/illustrations/productivity.png" alt="">
           </div>
           <h3>Easy Planning</h3>
           <p>Plan your routines effortlessly with intuitive reminders and a clean interface.</p>
@@ -659,9 +653,7 @@
       <div class="col-md-4">
         <div class="feature-card">
           <div class="icon-wrap">
-            <img src="../assets/images/Illustrations/planning.png" alt="">
-          <div class="mb-4 d-flex align-items-center justify-content-center" style="height: 60px;">
-            <img src="../assets/images/illustrations/planning.png" alt="">
+            <img src="assets/images/illustrations/planning.png" alt="">
           </div>
           <h3>Detailed Statistics</h3>
           <p>Analyze your daily performance with beautiful and minimal insights.</p>
@@ -671,9 +663,7 @@
       <div class="col-md-4">
         <div class="feature-card">
           <div class="icon-wrap">
-            <img src="../assets/images/Illustrations/reward.png" alt="">
-          <div class="mb-4 d-flex align-items-center justify-content-center" style="height: 60px;">
-            <img src="../assets/images/illustrations/reward.png" alt="">
+            <img src="assets/images/illustrations/reward.png" alt="">
           </div>
           <h3>Motivation</h3>
           <p>Stay inspired with curated content that keeps your momentum going.</p>
@@ -724,7 +714,7 @@
   <div class="container">
 
     <div class="footer-logo mb-4">
-      <img src="../assets/images/logos/logoWhite.png" alt="DayZen">
+      <img src="assets/images/logos/logoWhite.png" alt="DayZen">
     </div>
 
     <p class="copyright">© 2024 DayZen. All rights reserved.</p>


### PR DESCRIPTION
Moved index.html
Moved DayZen/pages/index.html to DayZen/index.html. This aligns with the documentation in the README.md and keeps the main landing page out of the pages/ directory.

Fixed Malformed Navigation Elements
The "About Us" and "Blog" navigation links had duplicate, nested, and unclosed <a> tags.
Cleaned up the navigation list items to only use a single valid <a> tag each.

Fixed Duplicate Features Images
The "Why Choose DayZen" feature cards (Easy Planning, Detailed Statistics, and Motivation) contained duplicate elements that broke the container layout (<div class="mb-4 ..."> alongside <div class="icon-wrap">).
Unified the HTML structure by using only the icon-wrap div as originally intended.

Corrected Asset Paths
After moving index.html, we had to fix relative references. ../assets/... became assets/... and the other page links (about.html, register.html, etc.) were updated to point into pages/.