### PR TITLE
Fix logo, brand name, and slogan positioning (#62)

### DIFF
--- a/DayZen/index.html
+++ b/DayZen/index.html
@@ -58,6 +58,13 @@
       letter-spacing: 1px;
     }
 
+    .navbar-brand .slogan {
+      font-size: 0.65rem;
+      color: var(--text-muted);
+      letter-spacing: 0.5px;
+      margin-top: 2px;
+    }
+
     .nav-link {
       font-size: 1rem;
       font-weight: 700;
@@ -556,7 +563,10 @@
       <!-- Logo -->
       <a class="navbar-brand d-flex align-items-center" href="#">
         <img src="assets/images/logos/logoWhite.png" alt="DayZen Logo" width="32" style="filter: invert(1);">
-        <h1 class="ms-3 mb-0">DayZen</h1>
+        <div class="ms-3 d-flex flex-column">
+          <h1 class="mb-0">DayZen</h1>
+          <small class="slogan">Set Your Time, Manage Your Day!</small>
+        </div>
       </a>
 
       <!-- Toggle -->


### PR DESCRIPTION
## Summary
- Fix logo and brand name overlapping by separating them into a flex column layout
- Add the missing slogan "Set Your Time, Manage Your Day!" below the brand name
- Add CSS styling for the slogan with muted color

## Fixes
Fixes #62 - Position of the brand name, logo, and slogan on the web page.

## Testing
- Open `DayZen/index.html` in browser and verify:
  - Logo and brand name no longer overlap
  - Slogan appears below the brand name in the navbar