### PR TITLE
Fix inactive email and discussion forum links in CONTRIBUTING.md (#61)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,6 +41,6 @@ If you encounter any issues during setup, please open an issue or ask for help i
 - Ensure that your code is well-documented and tested.
 
 ## Communication
-Feel free to reach out via [email] or in the project's [discussion forum].
+Feel free to reach out via [email](mailto:support@dayzen.app) or in the project's [discussion forum](https://github.com/brgkdm/DayZen-good-first-issue/discussions).
 
 We appreciate your contribution!


### PR DESCRIPTION
## Summary
- Fix inactive `[email]` placeholder by adding mailto: link (support@dayzen.app)
- Fix inactive `[discussion forum]` placeholder by adding link to GitHub Discussions

## Fixes
Fixes #61 - Link to moderator(s) email and project's discussion forum inactive.

## Testing
- Open CONTRIBUTING.md and verify both links are now clickable