### PR TITLE
Fix theme toggle listener conflict

### DIFF
--- a/DayZen/index.html
+++ b/DayZen/index.html
@@ -16,8 +16,6 @@
   <!-- Intro JS -->
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/intro.js/8.3.2/introjs.min.css"/>
 
-  <link rel="stylesheet" href="css/theme.css">
-
   <style>
     :root {
       --mint-light: #f2faf9;
@@ -114,6 +112,44 @@
       color: var(--text-dark);
       transform: translateY(-2px);
       box-shadow: 0 6px 25px rgba(0, 0, 0, 0.08);
+    }
+
+    body.dark-mode {
+      background-color: #121212;
+      color: #e0e0e0;
+    }
+
+    body.dark-mode .navbar {
+      background-color: #1f1f1f !important;
+      border-bottom-color: rgba(255, 255, 255, 0.08);
+    }
+
+    body.dark-mode .navbar-brand h1,
+    body.dark-mode .hero h2 {
+      color: #e0e0e0;
+    }
+
+    body.dark-mode .navbar-brand .slogan,
+    body.dark-mode .hero p {
+      color: #aeb8be;
+    }
+
+    body.dark-mode .nav-link {
+      color: #e0e0e0 !important;
+    }
+
+    body.dark-mode .hero {
+      background: linear-gradient(135deg, #1c1c1c 0%, #242424 100%);
+    }
+
+    body.dark-mode .btn-primary {
+      background-color: #0d6efd;
+      color: #ffffff;
+    }
+
+    body.dark-mode .btn-primary:hover {
+      background-color: #0b5ed7;
+      color: #ffffff;
     }
 
     /* Hero Section */

--- a/DayZen/index.html
+++ b/DayZen/index.html
@@ -16,6 +16,8 @@
   <!-- Intro JS -->
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/intro.js/8.3.2/introjs.min.css"/>
 
+  <link rel="stylesheet" href="css/theme.css">
+
   <style>
     :root {
       --mint-light: #f2faf9;
@@ -621,7 +623,7 @@
 
       <!-- Theme Icon -->
       <div class="ms-4 d-none d-lg-block">
-        <img src="assets/images/icons/sun.png" alt="Theme" width="20" style="cursor: pointer; opacity: 0.5;">
+        <img id="theme-icon" src="assets/images/icons/sun.png" alt="Toggle theme" width="20" style="cursor: pointer; opacity: 0.5;">
       </div>
 
     </div>

--- a/DayZen/js/script.js
+++ b/DayZen/js/script.js
@@ -109,20 +109,3 @@ document.addEventListener("DOMContentLoaded", function () {
     });
   }
 });
-
-// -------------------- THEME TOGGLE --------------------
-const themeIcon = document.getElementById("theme-icon");
-const body = document.body;
-
-if (themeIcon) {
-  themeIcon.addEventListener("click", function () {
-    body.classList.toggle("dark-mode");
-    body.classList.toggle("light-mode");
-
-    if (body.classList.contains("dark-mode")) {
-      themeIcon.src = "assets/images/moon_1.png";
-    } else {
-      themeIcon.src = "assets/images/sun.png";
-    }
-  });
-}


### PR DESCRIPTION
## Summary
- Recreates the valid part of #76 on top of current `main` without carrying over stale/conflicting changes. It looks like the PR author will not resolve the conflicts and there were additional issues:
- Removes the duplicate theme toggle listener from `js/script.js` so `js/theme-toggle.js` is the single owner.
- Reconnects the landing-page theme icon and adds landing-page-scoped dark-mode styles so the centralized toggle can apply the saved theme without overriding the existing light design.

## Validation
- Confirmed `index.html` loads `js/theme-toggle.js` only once.
- Confirmed `js/script.js` no longer references theme toggle state or icon paths.
- Smoke-tested `DayZen/index.html` locally: clicking the theme icon switches to dark mode, clicking again switches back to light mode, updates the icon, and persists `dayzen_theme`.
- Visually checked desktop and mobile version (via Chrome) in both light and dark modes.

## Context
This is a clean replacement for the stale/conflicted #76. It intentionally excludes the obsolete commented script include, unrelated `header.css` comment, and weaker `theme-toggle.js` refactor from that PR.