### PR TITLE
Fix mobile navbar not closing on outside click

### DIFF
--- a/DayZen/css/indexacc.css
+++ b/DayZen/css/indexacc.css
@@ -242,6 +242,7 @@ header h1 {
 }
 
 .overlay.open {
+    display: block;
     opacity: 1;
 }
 

--- a/DayZen/index.html
+++ b/DayZen/index.html
@@ -749,6 +749,24 @@
 <script src="js/onboarding.js"></script>
 
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
+
+//fixing the navbar collaspe when clicked outside of menu area//
+
+<script>
+  document.addEventListener("click", function (e) {
+    const navbar = document.querySelector(".navbar-collapse");
+    const toggler = document.querySelector(".navbar-toggler");
+
+    if (
+      navbar.classList.contains("show") &&
+      !navbar.contains(e.target) &&
+      !toggler.contains(e.target)
+    ) {
+      bootstrap.Collapse.getInstance(navbar).hide();
+    }
+  });
+</script>
+
 <script src="https://cdnjs.cloudflare.com/ajax/libs/intro.js/8.3.2/intro.min.js"></script>
 
 </body>

--- a/DayZen/js/header.js
+++ b/DayZen/js/header.js
@@ -22,6 +22,7 @@ document.addEventListener("DOMContentLoaded", function () {
             </nav>
         </header>
     `;
+        
 });
 
 window.addEventListener("scroll", () => {


### PR DESCRIPTION
Added Bootstrap collapse close behavior when users click outside the expanded mobile navbar.
Improves mobile UX and navigation behavior.