### PR TITLE
fix: add missing Privacy Policy and Terms of Service pages

### DIFF
--- a/DayZen/pages/privacy.html
+++ b/DayZen/pages/privacy.html
@@ -1,0 +1,107 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Privacy Policy - DayZen</title>
+    <link rel="stylesheet" href="../css/about.css">
+    <link rel="stylesheet" href="../css/footer.css">
+</head>
+<body class="page-fade">
+
+<!-- Hero Section -->
+<header class="hero">
+    <div class="hero-content">
+        <h1>Privacy Policy</h1>
+        <p>Your privacy matters to us</p>
+
+        <!-- Back to Home Button -->
+        <div class="back-home">
+            <a href="../index.html" class="btn-home">← Back to Home</a>
+        </div>
+    </div>
+</header>
+
+<!-- Privacy Content -->
+<main class="container" style="max-width: 900px; padding: 60px 20px;">
+    <section style="margin-bottom: 40px;">
+        <h2 style="margin-bottom: 20px; color: #2d3436;">Information We Collect</h2>
+        <p style="line-height: 1.8; color: #636e72;">
+            DayZen is a client-side application that stores your data locally in your browser. 
+            We do not collect, transmit, or store any personal information on external servers.
+        </p>
+    </section>
+
+    <section style="margin-bottom: 40px;">
+        <h2 style="margin-bottom: 20px; color: #2d3436;">Local Storage</h2>
+        <p style="line-height: 1.8; color: #636e72;">
+            Your routine data and preferences (such as theme settings) are stored in your browser's 
+            local storage. This data remains on your device and is never transmitted to our servers.
+        </p>
+    </section>
+
+    <section style="margin-bottom: 40px;">
+        <h2 style="margin-bottom: 20px; color: #2d3436;">Third-Party Services</h2>
+        <p style="line-height: 1.8; color: #636e72;">
+            DayZen uses the following third-party services loaded via CDN:
+        </p>
+        <ul style="line-height: 1.8; color: #636e72; margin-left: 20px;">
+            <li>Bootstrap CSS Framework (cdn.jsdelivr.net)</li>
+            <li>Intro.js Library (cdnjs.cloudflare.com)</li>
+            <li>Google Fonts (fonts.googleapis.com)</li>
+        </ul>
+        <p style="line-height: 1.8; color: #636e72; margin-top: 15px;">
+            These services may collect usage data according to their own privacy policies.
+        </p>
+    </section>
+
+    <section style="margin-bottom: 40px;">
+        <h2 style="margin-bottom: 20px; color: #2d3436;">Data Security</h2>
+        <p style="line-height: 1.8; color: #636e72;">
+            Since all data is stored locally on your device, you have full control over your information. 
+            Clearing your browser data will remove all DayZen-related information.
+        </p>
+    </section>
+
+    <section style="margin-bottom: 40px;">
+        <h2 style="margin-bottom: 20px; color: #2d3436;">Changes to This Policy</h2>
+        <p style="line-height: 1.8; color: #636e72;">
+            We may update this privacy policy from time to time. Any changes will be posted on this page 
+            with an updated revision date.
+        </p>
+    </section>
+
+    <section style="margin-bottom: 40px;">
+        <h2 style="margin-bottom: 20px; color: #2d3436;">Contact Us</h2>
+        <p style="line-height: 1.8; color: #636e72;">
+            If you have any questions about this Privacy Policy, please contact us through the 
+            <a href="../index.html#contact" style="color: #a8dadc; text-decoration: none;">contact form</a> 
+            on our homepage.
+        </p>
+    </section>
+
+    <p style="text-align: center; color: #636e72; margin-top: 60px; font-size: 0.9rem;">
+        Last updated: May 12, 2026
+    </p>
+</main>
+
+<footer class="footer text-center">
+    <div class="container">
+        <div class="footer-brand">
+            <img src="../assets/images/logos/logoWhite.png" alt="DayZen logo">
+            <h3>DayZen</h3>
+        </div>
+        <p>Turn every day into a calmer, more productive routine.</p>
+        <div class="footer-links">
+            <a href="../index.html">Home</a>
+            <a href="help.html">Help</a>
+            <a href="privacy.html">Privacy</a>
+            <a href="terms.html">Terms</a>
+        </div>
+        <div class="security-subtle">🔒 Secure routines, elegant design.</div>
+    </div>
+</footer>
+
+<script src="../js/script.js"></script>
+</body>
+</html>

--- a/DayZen/pages/terms.html
+++ b/DayZen/pages/terms.html
@@ -1,0 +1,129 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Terms of Service - DayZen</title>
+    <link rel="stylesheet" href="../css/about.css">
+    <link rel="stylesheet" href="../css/footer.css">
+</head>
+<body class="page-fade">
+
+<!-- Hero Section -->
+<header class="hero">
+    <div class="hero-content">
+        <h1>Terms of Service</h1>
+        <p>Please read these terms carefully</p>
+
+        <!-- Back to Home Button -->
+        <div class="back-home">
+            <a href="../index.html" class="btn-home">← Back to Home</a>
+        </div>
+    </div>
+</header>
+
+<!-- Terms Content -->
+<main class="container" style="max-width: 900px; padding: 60px 20px;">
+    <section style="margin-bottom: 40px;">
+        <h2 style="margin-bottom: 20px; color: #2d3436;">Acceptance of Terms</h2>
+        <p style="line-height: 1.8; color: #636e72;">
+            By accessing and using DayZen, you accept and agree to be bound by the terms and provisions 
+            of this agreement. If you do not agree to these terms, please do not use this service.
+        </p>
+    </section>
+
+    <section style="margin-bottom: 40px;">
+        <h2 style="margin-bottom: 20px; color: #2d3436;">Use of Service</h2>
+        <p style="line-height: 1.8; color: #636e72;">
+            DayZen is a free, open-source daily routine tracking application. You may use this service 
+            for personal, non-commercial purposes. The service is provided "as is" without any warranties.
+        </p>
+    </section>
+
+    <section style="margin-bottom: 40px;">
+        <h2 style="margin-bottom: 20px; color: #2d3436;">User Responsibilities</h2>
+        <p style="line-height: 1.8; color: #636e72;">
+            You are responsible for:
+        </p>
+        <ul style="line-height: 1.8; color: #636e72; margin-left: 20px;">
+            <li>Maintaining the security of your browser and device</li>
+            <li>Backing up your data (stored locally in your browser)</li>
+            <li>Using the service in compliance with applicable laws</li>
+            <li>Not attempting to disrupt or harm the service</li>
+        </ul>
+    </section>
+
+    <section style="margin-bottom: 40px;">
+        <h2 style="margin-bottom: 20px; color: #2d3436;">Data Storage</h2>
+        <p style="line-height: 1.8; color: #636e72;">
+            All data is stored locally in your browser. We are not responsible for data loss due to 
+            browser cache clearing, device failure, or other technical issues. We recommend regularly 
+            backing up important information.
+        </p>
+    </section>
+
+    <section style="margin-bottom: 40px;">
+        <h2 style="margin-bottom: 20px; color: #2d3436;">Intellectual Property</h2>
+        <p style="line-height: 1.8; color: #636e72;">
+            DayZen is an open-source project. The source code and design are available under the 
+            project's license. Third-party libraries and resources are subject to their respective licenses.
+        </p>
+    </section>
+
+    <section style="margin-bottom: 40px;">
+        <h2 style="margin-bottom: 20px; color: #2d3436;">Limitation of Liability</h2>
+        <p style="line-height: 1.8; color: #636e72;">
+            DayZen and its contributors shall not be liable for any direct, indirect, incidental, 
+            special, or consequential damages resulting from the use or inability to use this service.
+        </p>
+    </section>
+
+    <section style="margin-bottom: 40px;">
+        <h2 style="margin-bottom: 20px; color: #2d3436;">Modifications to Terms</h2>
+        <p style="line-height: 1.8; color: #636e72;">
+            We reserve the right to modify these terms at any time. Changes will be effective immediately 
+            upon posting. Your continued use of the service constitutes acceptance of the modified terms.
+        </p>
+    </section>
+
+    <section style="margin-bottom: 40px;">
+        <h2 style="margin-bottom: 20px; color: #2d3436;">Open Source Contributions</h2>
+        <p style="line-height: 1.8; color: #636e72;">
+            By contributing to DayZen, you agree that your contributions will be licensed under the 
+            same license as the project. Please review the CONTRIBUTING.md file for contribution guidelines.
+        </p>
+    </section>
+
+    <section style="margin-bottom: 40px;">
+        <h2 style="margin-bottom: 20px; color: #2d3436;">Contact Information</h2>
+        <p style="line-height: 1.8; color: #636e72;">
+            For questions about these Terms of Service, please reach out through our 
+            <a href="../index.html#contact" style="color: #a8dadc; text-decoration: none;">contact form</a>.
+        </p>
+    </section>
+
+    <p style="text-align: center; color: #636e72; margin-top: 60px; font-size: 0.9rem;">
+        Last updated: May 12, 2026
+    </p>
+</main>
+
+<footer class="footer text-center">
+    <div class="container">
+        <div class="footer-brand">
+            <img src="../assets/images/logos/logoWhite.png" alt="DayZen logo">
+            <h3>DayZen</h3>
+        </div>
+        <p>Turn every day into a calmer, more productive routine.</p>
+        <div class="footer-links">
+            <a href="../index.html">Home</a>
+            <a href="help.html">Help</a>
+            <a href="privacy.html">Privacy</a>
+            <a href="terms.html">Terms</a>
+        </div>
+        <div class="security-subtle">🔒 Secure routines, elegant design.</div>
+    </div>
+</footer>
+
+<script src="../js/script.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## 🐛 Bug Fix: Missing Privacy & Terms Pages

### Problem
The footer on `index.html` and other pages contained links to Privacy Policy and Terms of Service pages that didn't exist, resulting in 404 errors when users clicked them.

### Solution
Created two new pages following the project's existing structure and design patterns:
- `DayZen/pages/privacy.html` - Privacy Policy
- `DayZen/pages/terms.html` - Terms of Service

### Changes Made
- ✅ Created privacy policy page explaining local storage usage and data handling
- ✅ Created terms of service page with open source contribution terms
- ✅ Both pages use existing CSS (`about.css`, `footer.css`) for consistency
- ✅ Added proper navigation with "Back to Home" buttons
- ✅ Included consistent footer with working links to all pages
- ✅ Responsive design matching project standards
- ✅ Proper semantic HTML structure

### Testing Done
- [x] Tested all footer links work correctly from index.html
- [x] Verified "Back to Home" navigation works
- [x] Checked responsive design on mobile viewport
- [x] Confirmed page fade animations work properly
- [x] No console errors in browser DevTools
- [x] All images and assets load correctly

### Files Changed
- `DayZen/pages/privacy.html` (new file)
- `DayZen/pages/terms.html` (new file)

### Impact
- Fixes broken footer navigation
- Improves user trust with transparent privacy and terms information
- Provides important legal documentation for the project

---

**First contribution to GSSoC'26! 🎉**
